### PR TITLE
Bump calver-action to v1.20230620.0 to avoid month index issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cal Ver
-        uses: speechifyinc/calver-action@v1.20230427.0
+        uses: speechifyinc/calver-action@v1.20230620.0
         id: calver
         with:
           level: ${{ github.event.inputs.level }}


### PR DESCRIPTION
The previous version marked January as month 0 instead of month 1 as intended. Bumps the version to the first version with a fix